### PR TITLE
fixed req conflict 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.venv
+.venv*
 .resources
 __pycache__
 .pytest_cache
+.vscode

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
+pythonpath = .
 filterwarnings =
     ignore:.*torch_struct.distributions.TreeCRF.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Wand==0.6.10
 tokenizers==0.9.4
 transformers[torch,tokenizers]==4.2.2
 protobuf==3.20.3
-sentencepiece==0.1.91
+sentencepiece
 pytest
 svgling
 ipython


### PR DESCRIPTION
- pytest pass for 3.8, 3.9 and 3.10
- wheel error will appear for benepar, since they don't provide a wheel, pip will install via setup.py install instead
- 3.10 throws a requirement conflict error, no idea what functionality it breaks, but not the tests