### PR TITLE
Use a local import for export_figure.

### DIFF
--- a/constituent_treelib/core.py
+++ b/constituent_treelib/core.py
@@ -14,7 +14,6 @@ from typing import List, Dict, Set, Union, Generator
 
 # Package imports
 from .errors import *
-from .export import export_figure
 
 
 class Structure(Enum):
@@ -861,7 +860,7 @@ class ConstituentTree:
             verbose: If set to True, a short message about whether the output file creation was
             successful is displayed.
         """
-
+        from .export import export_figure
         export_figure(self.nltk_tree,
                       destination_filepath=destination_filepath,
                       wkhtmltopdf_bin_filepath=wkhtmltopdf_bin_filepath,


### PR DESCRIPTION
This avoids pulling in export_figure until it is actually needed, which in turn avoid a dependency on tkinter, which is not available on common Python installations such as those provisioned with `uv` or `pyenv`. Addresses issue #10.